### PR TITLE
Join teams patch

### DIFF
--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -224,8 +224,14 @@ export default class TeamsLinkApplicationCustomizer
           // launcher.html format being used, in order to mitigate that we have the following solution
           
           if (teamslink.includes("launcher/launcher.html?url=")) {
-            const joinUrl = decodeURIComponent(teamslink.split("url=")[1].split("&")[0]);
-            teamslink = 'https://teams.microsoft.com${joinUrl}';
+            try {
+              const params = new URLSearchParams(teamslink.split("?")[1]);
+              const decodedPath = decodeURIComponent(params.get("url") || "");
+              teamslink = `https://teams.microsoft.com${decodedPath}`;
+            } 
+            catch (e) {
+              console.error("Failed to decode launcher link:", e);
+            }
           }
 
           // redirect to a valid "Join MS Teams" URL patch 

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -275,11 +275,15 @@ export default class TeamsLinkApplicationCustomizer
   private createLink(teamsUrl): HTMLAnchorElement {
     const actionLink = document.createElement("a");
 
-    actionLink.href = teamsUrl;
+    actionLink.href = "#";
     actionLink.className = styles.actionsLink;
     actionLink.target = "_blank";
     actionLink.id = this.teamslinkId;
 
+    actionLink.addEventListener("click", (event) => {
+      event.preventDefault();
+      window.open(teamsUrl, "_blank", "noopener,noreferrer");
+    });
     return actionLink;
   }
 

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -219,7 +219,19 @@ export default class TeamsLinkApplicationCustomizer
       let teamslink = noTeamsLink
       for (const item of TeamsLinksList) {
         if(item.TeamsID === groupid){
-          teamslink = item.Teamslink
+          teamslink = item.Teamslink;
+
+          // redirect to a valid "Join MS Teams" URL patch 
+          // due to MS Teams moving on from legacy redirect
+          
+          if (teamslink.includes("_#/1/team/")) {
+            teamslink = teamslink.replace("_#/", "");
+          }
+          if (!teamslink.includes("web=1")) {
+            const separator = teamslink.includes("?") ? "&" : "?";
+            teamslink += `${separator}web=1`;
+          }
+
           break;
         }
       }

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -241,10 +241,9 @@ export default class TeamsLinkApplicationCustomizer
             teamslink = teamslink.replace("#/", "/");
           }
           
-          const hasQuery = teamslink.includes("?");
-          const separator = hasQuery ? "&" : "?";
+          const separator = teamslink.includes ("?") ? "&" : "?";
           if (!teamslink.includes("web=1")) {
-            teamslink +- `${separator}web=1&launchAgent=webapp`;
+            teamslink += `${separator}web=1&launchAgent=webapp`;
           }
           else if (!teamslink.includes("launchAgent=webapp")) {
             teamslink += `&launchAgent=webapp`;
@@ -252,7 +251,7 @@ export default class TeamsLinkApplicationCustomizer
           break;
         }
       }
-      return teamslink
+      return teamslink !== noTeamsLink ? teamslink : undefined;
     }).catch(function (error) {
       console.log(`Error:${error}`);
     });

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -235,9 +235,11 @@ export default class TeamsLinkApplicationCustomizer
           }
           if (!teamslink.includes("web=1")) {
             const separator = teamslink.includes("?") ? "&" : "?";
-            teamslink += `${separator}web=1`;
+            teamslink += `${separator}web=1&launchAgent=webapp`;
           }
-
+          else if (!teamslink.includes("launchAgent=webapp")) {
+            teamslink += "&launchAgent=webapp";
+          }
           break;
         }
       }

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -216,7 +216,7 @@ export default class TeamsLinkApplicationCustomizer
     }).then(function(jsonObject){
       const TeamsLinksList = jsonObject.value;
       //Get all item and check if matching groupid
-      let teamslink = noTeamsLink
+      let teamslink = noTeamsLink;
       for (const item of TeamsLinksList) {
         if(item.TeamsID === groupid){
           teamslink = item.Teamslink;
@@ -240,12 +240,14 @@ export default class TeamsLinkApplicationCustomizer
           else if (teamslink.includes("#/l/team/")) {
             teamslink = teamslink.replace("#/", "/");
           }
+          
+          const hasQuery = teamslink.includes("?");
+          const separator = hasQuery ? "&" : "?";
           if (!teamslink.includes("web=1")) {
-            const separator = teamslink.includes("?") ? "&" : "?";
-            teamslink += `${separator}web=1&launchAgent=webapp`;
+            teamslink +- `${separator}web=1&launchAgent=webapp`;
           }
           else if (!teamslink.includes("launchAgent=webapp")) {
-            teamslink += "&launchAgent=webapp";
+            teamslink += `&launchAgent=webapp`;
           }
           break;
         }

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -223,9 +223,15 @@ export default class TeamsLinkApplicationCustomizer
 
           // redirect to a valid "Join MS Teams" URL patch 
           // due to MS Teams moving on from legacy redirect
-          
-          if (teamslink.includes("_#/1/team/")) {
-            teamslink = teamslink.replace("_#/", "");
+
+          if (teamslink.includes("/v2/#/l/team/")) {
+            teamslink = teamslink.replace("/v2/#/", "/");
+          } 
+          else if (teamslink.includes("_#/l/team/")) {
+            teamslink = teamslink.replace("_#/", "/");
+          } 
+          else if (teamslink.includes("#/l/team/")) {
+            teamslink = teamslink.replace("#/", "/");
           }
           if (!teamslink.includes("web=1")) {
             const separator = teamslink.includes("?") ? "&" : "?";

--- a/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
+++ b/src/extensions/teamsLink/TeamsLinkApplicationCustomizer.ts
@@ -221,6 +221,13 @@ export default class TeamsLinkApplicationCustomizer
         if(item.TeamsID === groupid){
           teamslink = item.Teamslink;
 
+          // launcher.html format being used, in order to mitigate that we have the following solution
+          
+          if (teamslink.includes("launcher/launcher.html?url=")) {
+            const joinUrl = decodeURIComponent(teamslink.split("url=")[1].split("&")[0]);
+            teamslink = 'https://teams.microsoft.com${joinUrl}';
+          }
+
           // redirect to a valid "Join MS Teams" URL patch 
           // due to MS Teams moving on from legacy redirect
 


### PR DESCRIPTION
Please refer to: https://jira.tbs-sct.gc.ca/browse/GCCT-199

The following issue was arising: Community not displaying the join Pop-up when clicking on Join on MS teams, so users cannot join. 

After investigation, it was established this issue was arising because of a Microsoft Team update to the legacy URL format wherein the URL that redirects a user once they click on "Join Group on MS Teams" or "Joignez le groupe par MS Teams" does not need versions of included string values in the URL that let's a user join a team: 
- #/l/team/
- _#/l/team/, and
- /v2/#/l/team/

Additionally, forcing it to open default in web and traditionally connect to the Microsoft App should fix the issue and allow use to join a team directly via the Microsoft Teams App.

Please replicate the additions made to getTeamsURL for removing additonal string values found in the URL for the redirect for users to 'join a group on MS Teams'.